### PR TITLE
knox.createClient should accept a token

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,8 @@
     fromClient = knox.createClient({
       key: this.key,
       secret: this.secret,
-      bucket: fromBucket
+      bucket: fromBucket,
+      token: this.token
     });
     fromPrefix = fromPrefix && stripLeadingSlash(fromPrefix) || '';
     toPrefix = toPrefix && stripLeadingSlash(toPrefix) || '';

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -84,7 +84,7 @@ knox::streamKeys = ({prefix, maxKeysPerRequest}={}) ->
 
 knox::copyBucket = ({fromBucket, fromPrefix, toPrefix}, cb) ->
   fromBucket ?= @bucket
-  fromClient = knox.createClient {@key, @secret, bucket: fromBucket}
+  fromClient = knox.createClient {@key, @secret, bucket: fromBucket, @token}
   fromPrefix = fromPrefix and stripLeadingSlash(fromPrefix) or ''
   toPrefix = toPrefix and stripLeadingSlash(toPrefix) or ''
 


### PR DESCRIPTION
Knox has support for AWS Security Token Service: https://github.com/Automattic/knox#token

Knox copy should be compatible with this.