### PR TITLE
add headers arg to copyFileTo()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,9 +126,9 @@
   };
 
   knox.prototype.copyBucket = function(_arg, cb) {
-    var count, fail, failed, fromBucket, fromClient, fromPrefix, keyStream, toPrefix,
+    var count, fail, failed, fromBucket, fromClient, fromPrefix, headers, keyStream, toPrefix,
       _this = this;
-    fromBucket = _arg.fromBucket, fromPrefix = _arg.fromPrefix, toPrefix = _arg.toPrefix;
+    fromBucket = _arg.fromBucket, fromPrefix = _arg.fromPrefix, toPrefix = _arg.toPrefix, headers = _arg.headers;
     if (fromBucket == null) {
       fromBucket = this.bucket;
     }
@@ -157,7 +157,7 @@
       var toKey;
       toKey = swapPrefix(key, fromPrefix, toPrefix);
       return backoff(function(cb) {
-        return fromClient.copyFileTo(key, _this.bucket, toKey, function(err, res) {
+        return fromClient.copyFileTo(key, _this.bucket, toKey, headers, function(err, res) {
           if (err != null) {
             return cb(err);
           } else if (res.statusCode !== 200) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -82,7 +82,7 @@ knox::listPageOfKeys = ({maxKeys, marker, prefix, headers}, cb) ->
 knox::streamKeys = ({prefix, maxKeysPerRequest}={}) ->
   return new KeyStream {prefix, client: @, maxKeysPerRequest}
 
-knox::copyBucket = ({fromBucket, fromPrefix, toPrefix}, cb) ->
+knox::copyBucket = ({fromBucket, fromPrefix, toPrefix, headers}, cb) ->
   fromBucket ?= @bucket
   fromClient = knox.createClient {@key, @secret, bucket: fromBucket, @token}
   fromPrefix = fromPrefix and stripLeadingSlash(fromPrefix) or ''
@@ -106,7 +106,7 @@ knox::copyBucket = ({fromBucket, fromPrefix, toPrefix}, cb) ->
       toKey = swapPrefix(key, fromPrefix, toPrefix)
       backoff(
         (cb) =>
-          fromClient.copyFileTo key, @bucket, toKey, (err, res) ->
+          fromClient.copyFileTo key, @bucket, toKey, headers, (err, res) ->
             if err?
               cb err
             else if res.statusCode isnt 200


### PR DESCRIPTION
So you could copy files and make it publicly available. 

```
client.copyBucket({
    fromBucket: 'vluxe',
    fromPrefix: source + id + '/',
    toPrefix: dest + dest_id,
    headers: {
      'x-amz-acl': 'public-read'
    }
  }, callback)
```
