### PR TITLE
Support nonstandard regions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,8 @@
       key: this.key,
       secret: this.secret,
       bucket: fromBucket,
-      token: this.token
+      token: this.token,
+      region: this.region
     });
     fromPrefix = fromPrefix && stripLeadingSlash(fromPrefix) || '';
     toPrefix = toPrefix && stripLeadingSlash(toPrefix) || '';

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -84,7 +84,7 @@ knox::streamKeys = ({prefix, maxKeysPerRequest}={}) ->
 
 knox::copyBucket = ({fromBucket, fromPrefix, toPrefix}, cb) ->
   fromBucket ?= @bucket
-  fromClient = knox.createClient {@key, @secret, bucket: fromBucket, @token}
+  fromClient = knox.createClient {@key, @secret, bucket: fromBucket, @token, @region}
   fromPrefix = fromPrefix and stripLeadingSlash(fromPrefix) or ''
   toPrefix = toPrefix and stripLeadingSlash(toPrefix) or ''
 


### PR DESCRIPTION
This allows you to use regions such as `us-gov-cloud-1`.
